### PR TITLE
Fix JWT cache key path in ValidateJwt middleware

### DIFF
--- a/src/Http/Middleware/ValidateJwt.php
+++ b/src/Http/Middleware/ValidateJwt.php
@@ -29,11 +29,11 @@ class ValidateJwt
             return response()->json(['error' => 'Unauthorized'], Response::HTTP_UNAUTHORIZED);
         }
 
-        $token = substr($authHeader, 7);
+        $token = substr($authHeader, strlen((string)$prefix) + 1);
 
         try {
-            $publicKey = Cache::remember('jwt_cache_ttl', config('microservice.auth.public_key_ttl', 3600), function() {
-                return file_get_contents(config('microservice.auth.jwt_cache_ttl'));
+            $publicKey = Cache::remember('jwt_public_key', config('microservice.auth.jwt_cache_ttl', 3600), function() {
+                return file_get_contents(config('microservice.auth.jwt_public_key'));
             });
 
             $decoded = JWT::decode($token, new Key($publicKey, config('microservice.auth.jwt_algorithm')));


### PR DESCRIPTION
## Summary
- fix JWT middleware caching of public key
- handle dynamic token prefix length

## Testing
- `php -v` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852697ae710833391e568a3c970377b