### PR TITLE
Respect configured correlation ID length

### DIFF
--- a/src/Http/Middleware/CorrelationId.php
+++ b/src/Http/Middleware/CorrelationId.php
@@ -19,9 +19,13 @@ class CorrelationId
     {
         $cfg = config('microservice.correlation');
         $header = $cfg['header'];
+        $length = (int) ($cfg['length'] ?? 36);
 
-        // Use existing header or generate a new UUID
-        $id = $request->header($header) ?: Str::uuid()->toString();
+        // Use existing header or generate a new ID of the configured length
+        $id = $request->header($header);
+        if (! $id) {
+            $id = Str::random($length);
+        }
 
         // Set on request and response
         $request->headers->set($header, $id);

--- a/tests/Middleware/CorrelationIdTest.php
+++ b/tests/Middleware/CorrelationIdTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tests\Middleware;
+
+use Illuminate\Support\Facades\Route;
+use Kroderdev\LaravelMicroserviceCore\Http\Middleware\CorrelationId;
+use Orchestra\Testbench\TestCase;
+
+class CorrelationIdTest extends TestCase
+{
+    /** @test */
+    public function it_generates_default_length_correlation_id()
+    {
+        $header = 'X-Correlation-ID';
+        $length = 36;
+        config()->set('microservice.correlation.header', $header);
+        config()->set('microservice.correlation.length', $length);
+
+        Route::middleware(CorrelationId::class)->get('/correlation-default', fn () => response()->json(['ok' => true]));
+
+        $response = $this->get('/correlation-default');
+
+        $this->assertSame($length, strlen($response->headers->get($header)));
+    }
+
+    /** @test */
+    public function it_generates_configured_length_correlation_id()
+    {
+        $header = 'X-Correlation-ID';
+        $length = 20;
+        config()->set('microservice.correlation.header', $header);
+        config()->set('microservice.correlation.length', $length);
+
+        Route::middleware(CorrelationId::class)->get('/correlation-custom', fn () => response()->json(['ok' => true]));
+
+        $response = $this->get('/correlation-custom');
+
+        $this->assertSame($length, strlen($response->headers->get($header)));
+    }
+}


### PR DESCRIPTION
## Summary
- read correlation ID length from config and generate random ID when missing
- cover default and custom ID lengths in new tests

## Testing
- `composer run print-test`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_689d0e2573e88333984a36b5493eb3a4