### PR TITLE
Add type hints to gateway utilities

### DIFF
--- a/src/Auth/GatewayGuard.php
+++ b/src/Auth/GatewayGuard.php
@@ -45,7 +45,7 @@ class GatewayGuard extends SessionGuard
      *
      * @return mixed|null
      */
-    public function user()
+    public function user(): ?AuthenticatableContract
     {
         if ($this->loggedOut) {
             return null;
@@ -139,7 +139,7 @@ class GatewayGuard extends SessionGuard
      * @param  string  $token
      * @return void
      */
-    protected function updateSession($token)
+    protected function updateSession($token): void
     {
         $this->session->put($this->getName(), $token);
         // $this->session->migrate(true); Conflicts with CSRF
@@ -163,7 +163,7 @@ class GatewayGuard extends SessionGuard
      * @param  bool  $remember
      * @return bool
      */
-    public function attempt(array $credentials = [], $remember = false)
+    public function attempt(array $credentials = [], $remember = false): bool
     {
         $response = $this->client->login($credentials);
         $token = $response['access_token'] ?? null;
@@ -190,7 +190,7 @@ class GatewayGuard extends SessionGuard
      *
      * @param  bool  $remember
      */
-    public function loginWithToken(string $token, array $userData = [], $remember = false): void
+    public function loginWithToken(string $token, array $userData = [], bool $remember = false): void
     {
         $this->token = $token;
         $this->updateSession($token);
@@ -216,7 +216,7 @@ class GatewayGuard extends SessionGuard
      * @param  bool  $remember
      * @return void
      */
-    public function login(AuthenticatableContract $user, $remember = false)
+    public function login(AuthenticatableContract $user, $remember = false): void
     {
         $this->setUser($user);
         $this->fireLoginEvent($user, $remember);
@@ -227,7 +227,7 @@ class GatewayGuard extends SessionGuard
      *
      * @return void
      */
-    public function logout()
+    public function logout(): void
     {
         $this->clearUserDataFromStorage();
         $this->token = null;
@@ -240,7 +240,7 @@ class GatewayGuard extends SessionGuard
      *
      * @return bool
      */
-    public function viaRemember()
+    public function viaRemember(): bool
     {
         return false;
     }

--- a/src/Console/ModelMakeCommand.php
+++ b/src/Console/ModelMakeCommand.php
@@ -9,14 +9,14 @@ use Symfony\Component\Console\Input\InputOption;
 #[AsCommand(name: 'make:model', description: 'Create a new Eloquent model class')]
 class ModelMakeCommand extends BaseModelMakeCommand
 {
-    protected function getOptions()
+    protected function getOptions(): array
     {
         return array_merge(parent::getOptions(), [
             ['remote', null, InputOption::VALUE_NONE, 'Indicates the model should extend the package base model'],
         ]);
     }
 
-    protected function getStub()
+    protected function getStub(): string
     {
         if ($this->option('remote')) {
             return __DIR__.'/stubs/remote-model.stub';

--- a/src/Contracts/ApiGatewayClientInterface.php
+++ b/src/Contracts/ApiGatewayClientInterface.php
@@ -4,11 +4,11 @@ namespace Kroderdev\LaravelMicroserviceCore\Contracts;
 
 interface ApiGatewayClientInterface
 {
-    public function get(string $uri, array $query = []);
+    public function get(string $uri, array $query = []): mixed;
 
-    public function post(string $uri, array $data = []);
+    public function post(string $uri, array $data = []): mixed;
 
-    public function put(string $uri, array $data = []);
+    public function put(string $uri, array $data = []): mixed;
 
-    public function delete(string $uri);
+    public function delete(string $uri): mixed;
 }

--- a/src/Services/ApiGatewayClient.php
+++ b/src/Services/ApiGatewayClient.php
@@ -36,35 +36,35 @@ class ApiGatewayClient implements ApiGatewayClientInterface
         return new static(Http::apiGatewayDirectWithToken($token));
     }
 
-    public function get(string $uri, array $query = [])
+    public function get(string $uri, array $query = []): mixed
     {
         return $this->handleResponse(
             $this->http->get($uri, $query)
         );
     }
 
-    public function post(string $uri, array $data = [])
+    public function post(string $uri, array $data = []): mixed
     {
         return $this->handleResponse(
             $this->http->post($uri, $data)
         );
     }
 
-    public function put(string $uri, array $data = [])
+    public function put(string $uri, array $data = []): mixed
     {
         return $this->handleResponse(
             $this->http->put($uri, $data)
         );
     }
 
-    public function delete(string $uri)
+    public function delete(string $uri): mixed
     {
         return $this->handleResponse(
             $this->http->delete($uri)
         );
     }
 
-    protected function handleResponse($response)
+    protected function handleResponse(mixed $response): mixed
     {
         if (is_object($response) && method_exists($response, 'failed') && $response->failed()) {
             $data = method_exists($response, 'json') ? $response->json() : [];

--- a/src/Traits/RedirectsIfRequested.php
+++ b/src/Traits/RedirectsIfRequested.php
@@ -9,7 +9,7 @@ use Illuminate\Support\Facades\Session;
 
 trait RedirectsIfRequested
 {
-    protected function redirectIfRequested(Request $request, $response)
+    protected function redirectIfRequested(Request $request, mixed $response): mixed
     {
         if ($request->has('redirect')) {
             $redirectTo = $request->input('redirect');

--- a/tests/Models/ApiModelTest.php
+++ b/tests/Models/ApiModelTest.php
@@ -66,7 +66,7 @@ class ApiModelTest extends TestCase
     {
         // Simulate the gateway returning an array of users
         $this->gateway = new class () extends FakeGatewayClient {
-            public function get(string $uri, array $query = [])
+            public function get(string $uri, array $query = []): mixed
             {
                 parent::get($uri, $query);
 
@@ -90,7 +90,7 @@ class ApiModelTest extends TestCase
     public function find_users_gateway()
     {
         $this->gateway = new class () extends FakeGatewayClient {
-            public function get(string $uri, array $query = [])
+            public function get(string $uri, array $query = []): mixed
             {
                 parent::get($uri, $query);
                 if ($uri === '/users/5') {
@@ -113,7 +113,7 @@ class ApiModelTest extends TestCase
     public function find_users_gateway_returns_null_when_not_found()
     {
         $this->gateway = new class () extends FakeGatewayClient {
-            public function get(string $uri, array $query = [])
+            public function get(string $uri, array $query = []): mixed
             {
                 parent::get($uri, $query);
 
@@ -131,7 +131,7 @@ class ApiModelTest extends TestCase
     public function create_users_gateway()
     {
         $this->gateway = new class () extends FakeGatewayClient {
-            public function post(string $uri, array $data = [])
+            public function post(string $uri, array $data = []): mixed
             {
                 parent::post($uri, $data);
 
@@ -152,7 +152,7 @@ class ApiModelTest extends TestCase
     public function all_users_gateway_handles_empty_response()
     {
         $this->gateway = new class () extends FakeGatewayClient {
-            public function get(string $uri, array $query = [])
+            public function get(string $uri, array $query = []): mixed
             {
                 parent::get($uri, $query);
 
@@ -171,7 +171,7 @@ class ApiModelTest extends TestCase
     public function all_users_gateway_handles_api_failure()
     {
         $this->gateway = new class () extends FakeGatewayClient {
-            public function get(string $uri, array $query = [])
+            public function get(string $uri, array $query = []): mixed
             {
                 parent::get($uri, $query);
 
@@ -242,7 +242,7 @@ class ApiModelTest extends TestCase
     public function delete_returns_false_on_failed_response()
     {
         $this->gateway = new class () extends FakeGatewayClient {
-            public function delete(string $uri)
+            public function delete(string $uri): mixed
             {
                 parent::delete($uri);
 
@@ -266,7 +266,7 @@ class ApiModelTest extends TestCase
     public function static_update_users_gateway()
     {
         $this->gateway = new class () extends FakeGatewayClient {
-            public function put(string $uri, array $data = [])
+            public function put(string $uri, array $data = []): mixed
             {
                 parent::put($uri, $data);
 
@@ -286,7 +286,7 @@ class ApiModelTest extends TestCase
     public function static_update_returns_false_on_failed_response()
     {
         $this->gateway = new class () extends FakeGatewayClient {
-            public function put(string $uri, array $data = [])
+            public function put(string $uri, array $data = []): mixed
             {
                 parent::put($uri, $data);
 
@@ -327,7 +327,7 @@ class ApiModelTest extends TestCase
     public function update_returns_false_on_failed_response()
     {
         $this->gateway = new class () extends FakeGatewayClient {
-            public function put(string $uri, array $data = [])
+            public function put(string $uri, array $data = []): mixed
             {
                 parent::put($uri, $data);
 
@@ -356,7 +356,7 @@ class ApiModelTest extends TestCase
     public function update_propagates_api_gateway_exceptions()
     {
         $this->gateway = new class () extends FakeGatewayClient {
-            public function put(string $uri, array $data = [])
+            public function put(string $uri, array $data = []): mixed
             {
                 parent::put($uri, $data);
 
@@ -377,7 +377,7 @@ class ApiModelTest extends TestCase
     public function find_or_fail_throws_when_not_found()
     {
         $this->gateway = new class () extends FakeGatewayClient {
-            public function get(string $uri, array $query = [])
+            public function get(string $uri, array $query = []): mixed
             {
                 parent::get($uri, $query);
 
@@ -395,7 +395,7 @@ class ApiModelTest extends TestCase
     public function update_or_fail_throws_on_failure()
     {
         $this->gateway = new class () extends FakeGatewayClient {
-            public function put(string $uri, array $data = [])
+            public function put(string $uri, array $data = []): mixed
             {
                 parent::put($uri, $data);
 
@@ -421,7 +421,7 @@ class ApiModelTest extends TestCase
     public function where_get_filters_results()
     {
         $this->gateway = new class () extends FakeGatewayClient {
-            public function get(string $uri, array $query = [])
+            public function get(string $uri, array $query = []): mixed
             {
                 parent::get($uri, $query);
 
@@ -493,7 +493,7 @@ class ApiModelTest extends TestCase
     public function paginate_returns_empty_paginator_on_404()
     {
         $this->gateway = new class () extends FakeGatewayClient {
-            public function get(string $uri, array $query = [])
+            public function get(string $uri, array $query = []): mixed
             {
                 parent::get($uri, $query);
 

--- a/tests/Rules/ExistsRemoteTest.php
+++ b/tests/Rules/ExistsRemoteTest.php
@@ -38,7 +38,7 @@ class ExistsRemoteTest extends TestCase
     public function passes_when_all_ids_exist()
     {
         $this->gateway = new class () extends FakeGatewayClient {
-            public function get(string $uri, array $query = [])
+            public function get(string $uri, array $query = []): mixed
             {
                 parent::get($uri, $query);
                 if (in_array($uri, ['/roles/1', '/roles/2'])) {
@@ -63,7 +63,7 @@ class ExistsRemoteTest extends TestCase
     public function rule_object_works_the_same()
     {
         $this->gateway = new class () extends FakeGatewayClient {
-            public function get(string $uri, array $query = [])
+            public function get(string $uri, array $query = []): mixed
             {
                 parent::get($uri, $query);
                 return ['data' => ['id' => (int) substr($uri, 7)]];
@@ -82,7 +82,7 @@ class ExistsRemoteTest extends TestCase
     public function fails_when_any_id_is_missing()
     {
         $this->gateway = new class () extends FakeGatewayClient {
-            public function get(string $uri, array $query = [])
+            public function get(string $uri, array $query = []): mixed
             {
                 parent::get($uri, $query);
                 if ($uri === '/roles/1') {

--- a/tests/Services/FakeGatewayClient.php
+++ b/tests/Services/FakeGatewayClient.php
@@ -8,28 +8,28 @@ class FakeGatewayClient implements ApiGatewayClientInterface
 {
     protected array $calls = [];
 
-    public function get(string $uri, array $query = [])
+    public function get(string $uri, array $query = []): mixed
     {
         $this->calls[] = ['method' => 'GET', 'uri' => $uri, 'query' => $query];
 
         return collect(['fake' => true, 'uri' => $uri, 'query' => $query]);
     }
 
-    public function post(string $uri, array $data = [])
+    public function post(string $uri, array $data = []): mixed
     {
         $this->calls[] = ['method' => 'POST', 'uri' => $uri, 'data' => $data];
 
         return collect(['fake' => true, 'uri' => $uri, 'data' => $data]);
     }
 
-    public function put(string $uri, array $data = [])
+    public function put(string $uri, array $data = []): mixed
     {
         $this->calls[] = ['method' => 'PUT', 'uri' => $uri, 'data' => $data];
 
         return collect(['fake' => true, 'uri' => $uri, 'data' => $data]);
     }
 
-    public function delete(string $uri)
+    public function delete(string $uri): mixed
     {
         $this->calls[] = ['method' => 'DELETE', 'uri' => $uri];
 

--- a/tests/Services/PermissionsClientTest.php
+++ b/tests/Services/PermissionsClientTest.php
@@ -27,7 +27,7 @@ class PermissionsClientTest extends TestCase
     {
         parent::setUp();
         $this->gateway = new class () extends FakeGatewayClient {
-            public function get(string $uri, array $query = [])
+            public function get(string $uri, array $query = []): mixed
             {
                 parent::get($uri, $query);
 


### PR DESCRIPTION
## Summary
- type ApiGateway client methods
- add return types to GatewayGuard and helpers
- update tests for new method signatures

## Testing
- `composer run print-test`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_689d6d708ec483338d55fdabee5b8a78