### PR TITLE
Add JWT validator service and refactor auth components

### DIFF
--- a/src/Providers/MicroserviceServiceProvider.php
+++ b/src/Providers/MicroserviceServiceProvider.php
@@ -24,6 +24,7 @@ use Kroderdev\LaravelMicroserviceCore\Services\ApiGatewayClient;
 use Kroderdev\LaravelMicroserviceCore\Services\ApiGatewayClientFactory;
 use Kroderdev\LaravelMicroserviceCore\Services\AuthServiceClient;
 use Kroderdev\LaravelMicroserviceCore\Services\PermissionsClient;
+use Kroderdev\LaravelMicroserviceCore\Services\JwtValidator;
 
 class MicroserviceServiceProvider extends ServiceProvider
 {
@@ -43,6 +44,7 @@ class MicroserviceServiceProvider extends ServiceProvider
         $this->app->bind(ApiGatewayClientInterface::class, fn ($app) => $app->make(ApiGatewayClientFactory::class)->default());
         $this->app->scoped(PermissionsClient::class, fn ($app) => new PermissionsClient($app->make(ApiGatewayClientInterface::class)));
         $this->app->singleton(AuthServiceClient::class, fn () => new AuthServiceClient());
+        $this->app->singleton(JwtValidator::class, fn () => new JwtValidator());
 
         $this->app->singleton(\Illuminate\Foundation\Console\ModelMakeCommand::class, function ($app) {
             return new \Kroderdev\LaravelMicroserviceCore\Console\ModelMakeCommand($app['files']);
@@ -75,7 +77,8 @@ class MicroserviceServiceProvider extends ServiceProvider
                 $provider,
                 $app['session.store'],
                 $app->make('request'),
-                $app->make(AuthServiceClient::class)
+                $app->make(AuthServiceClient::class),
+                $app->make(JwtValidator::class)
             );
 
             $guard->setCookieJar($app['cookie']);

--- a/src/Services/JwtValidator.php
+++ b/src/Services/JwtValidator.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Kroderdev\LaravelMicroserviceCore\Services;
+
+use Firebase\JWT\JWT;
+use Firebase\JWT\Key;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Log;
+
+class JwtValidator
+{
+    public function decode(string $token): object
+    {
+        $publicKey = $this->getPublicKey();
+
+        return JWT::decode($token, new Key($publicKey, config('microservice.auth.jwt_algorithm')));
+    }
+
+    public function isValid(string $token): bool
+    {
+        try {
+            $this->decode($token);
+
+            return true;
+        } catch (\Throwable $e) {
+            Log::warning('JWT decode failed', [
+                'error' => $e->getMessage(),
+                'token' => $token,
+            ]);
+
+            return false;
+        }
+    }
+
+    protected function getPublicKey(): string
+    {
+        return Cache::remember('jwt_public_key', config('microservice.auth.jwt_cache_ttl', 3600), function () {
+            $path = config('microservice.auth.jwt_public_key');
+            Log::info('Loaded JWT public key for token validation', ['path' => $path]);
+
+            return file_get_contents($path);
+        });
+    }
+}

--- a/tests/Auth/GatewayGuardTest.php
+++ b/tests/Auth/GatewayGuardTest.php
@@ -11,6 +11,7 @@ use Kroderdev\LaravelMicroserviceCore\Auth\ExternalUser;
 use Kroderdev\LaravelMicroserviceCore\Auth\GatewayGuard;
 use Kroderdev\LaravelMicroserviceCore\Providers\MicroserviceServiceProvider;
 use Kroderdev\LaravelMicroserviceCore\Services\AuthServiceClient;
+use Kroderdev\LaravelMicroserviceCore\Services\JwtValidator;
 use Orchestra\Testbench\TestCase;
 
 class FakeAuthServiceClient extends AuthServiceClient
@@ -100,7 +101,8 @@ EOD;
                 $provider,
                 $app['session.store'],
                 $app->make('request'),
-                $app->make(AuthServiceClient::class)
+                $app->make(AuthServiceClient::class),
+                $app->make(JwtValidator::class)
             );
         });
 

--- a/tests/Http/GatewayAuthControllersTest.php
+++ b/tests/Http/GatewayAuthControllersTest.php
@@ -14,6 +14,7 @@ use Kroderdev\LaravelMicroserviceCore\Http\Auth\RegisterController;
 use Kroderdev\LaravelMicroserviceCore\Http\Auth\SocialiteController;
 use Kroderdev\LaravelMicroserviceCore\Providers\MicroserviceServiceProvider;
 use Kroderdev\LaravelMicroserviceCore\Services\AuthServiceClient;
+use Kroderdev\LaravelMicroserviceCore\Services\JwtValidator;
 use Orchestra\Testbench\TestCase;
 
 class FakeAuthServiceClient extends AuthServiceClient
@@ -60,7 +61,8 @@ class GatewayAuthControllersTest extends TestCase
                 $provider,
                 $app['session.store'],
                 $app->make('request'),
-                $app->make(AuthServiceClient::class)
+                $app->make(AuthServiceClient::class),
+                $app->make(JwtValidator::class)
             );
         });
 


### PR DESCRIPTION
## Summary
- add reusable `JwtValidator` service for cached public key retrieval and token decoding
- refactor `GatewayGuard` and `ValidateJwt` middleware to leverage the validator
- update service provider and tests to wire in the validator

## Testing
- `composer run print-test`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_689d6d8cd4d88333b4898985dd8b6a07